### PR TITLE
[STEP09][STEP10] 이재호 - e-commerce

### DIFF
--- a/src/main/java/kr/hhplus/be/server/coupon/domain/repository/CouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/domain/repository/CouponRepository.java
@@ -1,14 +1,15 @@
 package kr.hhplus.be.server.coupon.domain.repository;
 
 import kr.hhplus.be.server.coupon.domain.model.CouponJPA;
-import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface CouponRepository extends CrudRepository<CouponJPA, Long> {
+public interface CouponRepository{
 
-    Optional<CouponJPA> findByCouponId(Long couponId);
+    Optional<CouponJPA> findById(Long couponId);
+
+    CouponJPA save(CouponJPA couponJPA);
 
     List<CouponJPA> findAll();
 }

--- a/src/main/java/kr/hhplus/be/server/coupon/domain/repository/CouponUserRepository.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/domain/repository/CouponUserRepository.java
@@ -1,14 +1,15 @@
 package kr.hhplus.be.server.coupon.domain.repository;
 
 import kr.hhplus.be.server.coupon.domain.model.CouponUserJPA;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface CouponUserRepository extends JpaRepository<CouponUserJPA, Long> {
+public interface CouponUserRepository{
 
     Optional<CouponUserJPA> findByUserIdAndCouponId(Long userId, Long couponId);
 
     List<CouponUserJPA> findAll();
+
+    CouponUserJPA save(CouponUserJPA couponUserJPA);
 }

--- a/src/main/java/kr/hhplus/be/server/coupon/domain/service/CouponCheckService.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/domain/service/CouponCheckService.java
@@ -17,6 +17,11 @@ public class CouponCheckService {
     private final CouponRepository couponRepository;
     private final CouponUserRepository couponUserRepository;
 
+    public void checkIfValidCouponNullable(Long userId, Long couponId) {
+        if (couponId == null) return;
+        checkCoupon(userId, couponId);
+    }
+
     public void checkCoupon(long userId, long couponId) {
         Coupon coupon = couponRepository.findById(couponId)
                 .map(Coupon::fromEntity)  // JPA → 도메인 변환

--- a/src/main/java/kr/hhplus/be/server/coupon/domain/service/CouponDiscountService.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/domain/service/CouponDiscountService.java
@@ -4,12 +4,10 @@ import kr.hhplus.be.server.coupon.domain.model.CouponUserJPA;
 import kr.hhplus.be.server.coupon.domain.repository.CouponRepository;
 import kr.hhplus.be.server.coupon.domain.repository.CouponUserRepository;
 import kr.hhplus.be.server.coupon.domain.service.dto.Coupon;
-import kr.hhplus.be.server.coupon.domain.service.dto.CouponUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,7 +17,7 @@ public class CouponDiscountService {
     private final CouponUserRepository couponUserRepository;
 
     public int getDiscountPercent(Long couponId) {
-        return couponRepository.findByCouponId(couponId)
+        return couponRepository.findById(couponId)
                 .map(Coupon::fromEntity)
                 .map(Coupon::getDiscountAmount)
                 .orElse(0);  // 존재하지 않으면 0%
@@ -35,4 +33,8 @@ public class CouponDiscountService {
        couponUser.setIsUsed(true);
       couponUser.setUsedAt(LocalDateTime.now());
    }
+
+
 }
+
+

--- a/src/main/java/kr/hhplus/be/server/coupon/domain/service/CouponIssuedService.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/domain/service/CouponIssuedService.java
@@ -29,7 +29,7 @@ public class CouponIssuedService {
     }
 
     public CouponUser issueCouponToUser(Long couponId, Long userId) {
-        Coupon coupon = couponRepo.findByCouponId(couponId)
+        Coupon coupon = couponRepo.findById(couponId)
                 .map(Coupon::fromEntity) // CouponJPA -> Coupon
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
 

--- a/src/main/java/kr/hhplus/be/server/coupon/infrastructure/CouponRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/infrastructure/CouponRepositoryImpl.java
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.coupon.infrastructure;
+
+import kr.hhplus.be.server.coupon.domain.model.CouponJPA;
+import kr.hhplus.be.server.coupon.domain.repository.CouponRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class CouponRepositoryImpl implements CouponRepository {
+
+    private final SpringDataCouponRepository jpaRepository;
+
+    public CouponRepositoryImpl(SpringDataCouponRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<CouponJPA> findById(Long couponId) {
+        return jpaRepository.findById(couponId);
+    }
+
+    @Override
+    public CouponJPA save(CouponJPA couponJPA) {
+        return jpaRepository.save(couponJPA);
+    }
+
+    @Override
+    public List<CouponJPA> findAll() {
+        return jpaRepository.findAll();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/coupon/infrastructure/CouponUserRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/infrastructure/CouponUserRepositoryImpl.java
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.coupon.infrastructure;
+
+import kr.hhplus.be.server.coupon.domain.model.CouponUserJPA;
+import kr.hhplus.be.server.coupon.domain.repository.CouponUserRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class CouponUserRepositoryImpl implements CouponUserRepository {
+
+    private final SpringDataCouponUserRepository jpaRepository;
+
+    public CouponUserRepositoryImpl(SpringDataCouponUserRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<CouponUserJPA> findByUserIdAndCouponId(Long userId, Long couponId) {
+        return jpaRepository.findByUserIdAndCouponId(userId, couponId);
+    }
+
+    @Override
+    public List<CouponUserJPA> findAll() {
+        return jpaRepository.findAll();
+    }
+
+    @Override
+    public CouponUserJPA save(CouponUserJPA couponUserJPA) {
+        return jpaRepository.save(couponUserJPA);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/coupon/infrastructure/SpringDataCouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/infrastructure/SpringDataCouponRepository.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.coupon.infrastructure;
+
+import kr.hhplus.be.server.coupon.domain.model.CouponJPA;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataCouponRepository extends JpaRepository<CouponJPA, Long> {
+}

--- a/src/main/java/kr/hhplus/be/server/coupon/infrastructure/SpringDataCouponUserRepository.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/infrastructure/SpringDataCouponUserRepository.java
@@ -1,0 +1,11 @@
+package kr.hhplus.be.server.coupon.infrastructure;
+
+import kr.hhplus.be.server.coupon.domain.model.CouponUserJPA;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SpringDataCouponUserRepository extends JpaRepository<CouponUserJPA, Long> {
+    Optional<CouponUserJPA> findByUserIdAndCouponId(Long userId, Long couponId);
+
+}

--- a/src/main/java/kr/hhplus/be/server/order/domain/repository/OrderHistoryRepository.java
+++ b/src/main/java/kr/hhplus/be/server/order/domain/repository/OrderHistoryRepository.java
@@ -1,11 +1,10 @@
 package kr.hhplus.be.server.order.domain.repository;
 
+
 import kr.hhplus.be.server.order.domain.model.OrderHistoryJPA;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
+public interface OrderHistoryRepository{
 
-@Repository
-public interface OrderHistoryRepository extends JpaRepository<OrderHistoryJPA, Long> {
+    OrderHistoryJPA save(OrderHistoryJPA orderHistoryJPA);
 
 }

--- a/src/main/java/kr/hhplus/be/server/order/domain/repository/OrderItemRepository.java
+++ b/src/main/java/kr/hhplus/be/server/order/domain/repository/OrderItemRepository.java
@@ -1,12 +1,11 @@
 package kr.hhplus.be.server.order.domain.repository;
 
+
 import kr.hhplus.be.server.order.domain.model.OrderItemJPA;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import kr.hhplus.be.server.order.domain.service.dto.OrderItem;
 
-import java.util.List;
+public interface OrderItemRepository{
 
-@Repository
-public interface OrderItemRepository extends JpaRepository<OrderItemJPA, Long> {
+    OrderItemJPA save(OrderItemJPA orderItemJPA);
 
 }

--- a/src/main/java/kr/hhplus/be/server/order/domain/repository/OrderRepository.java
+++ b/src/main/java/kr/hhplus/be/server/order/domain/repository/OrderRepository.java
@@ -1,9 +1,12 @@
 package kr.hhplus.be.server.order.domain.repository;
 
-import kr.hhplus.be.server.order.domain.model.OrderJPA;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
-public interface OrderRepository extends JpaRepository<OrderJPA, Long> {
+import kr.hhplus.be.server.order.domain.model.OrderJPA;
+
+import java.util.Optional;
+
+public interface OrderRepository{
+
+    Optional<OrderJPA> findById(Long orderId);
+    OrderJPA save(OrderJPA orderJPA);
 }

--- a/src/main/java/kr/hhplus/be/server/order/infrastructure/OrderHistoryRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/order/infrastructure/OrderHistoryRepositoryImpl.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.order.infrastructure;
+
+import kr.hhplus.be.server.order.domain.model.OrderHistoryJPA;
+import kr.hhplus.be.server.order.domain.repository.OrderHistoryRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public class OrderHistoryRepositoryImpl implements OrderHistoryRepository {
+
+    private final SpringDataOrderHistoryRepository jpaRepository;
+
+    public OrderHistoryRepositoryImpl(SpringDataOrderHistoryRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public OrderHistoryJPA save(OrderHistoryJPA orderHistoryJPA) {
+        return jpaRepository.save(orderHistoryJPA);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/order/infrastructure/OrderItemRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/order/infrastructure/OrderItemRepositoryImpl.java
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.order.infrastructure;
+
+import kr.hhplus.be.server.order.domain.model.OrderItemJPA;
+import kr.hhplus.be.server.order.domain.repository.OrderItemRepository;
+import kr.hhplus.be.server.order.domain.service.dto.OrderItem;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public class OrderItemRepositoryImpl implements OrderItemRepository {
+
+
+    private final SpringDataOrderItemRepository jpaRepository;
+
+    public OrderItemRepositoryImpl(SpringDataOrderItemRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public OrderItemJPA save(OrderItemJPA orderItemJPA) {
+        return jpaRepository.save(orderItemJPA);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/order/infrastructure/OrderRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/order/infrastructure/OrderRepositoryImpl.java
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.order.infrastructure;
+
+import kr.hhplus.be.server.order.domain.model.OrderJPA;
+import kr.hhplus.be.server.order.domain.repository.OrderRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class OrderRepositoryImpl implements OrderRepository {
+
+    private final SpringDataOrderRepository jpaRepository;
+
+    public OrderRepositoryImpl(SpringDataOrderRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<OrderJPA> findById(Long orderId) {
+        return jpaRepository.findById(orderId);
+    }
+
+    @Override
+    public OrderJPA save(OrderJPA orderJPA) {
+        return jpaRepository.save(orderJPA);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/order/infrastructure/SpringDataOrderHistoryRepository.java
+++ b/src/main/java/kr/hhplus/be/server/order/infrastructure/SpringDataOrderHistoryRepository.java
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.order.infrastructure;
+
+import kr.hhplus.be.server.order.domain.model.OrderHistoryJPA;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataOrderHistoryRepository extends JpaRepository<OrderHistoryJPA, Long> {
+}

--- a/src/main/java/kr/hhplus/be/server/order/infrastructure/SpringDataOrderItemRepository.java
+++ b/src/main/java/kr/hhplus/be/server/order/infrastructure/SpringDataOrderItemRepository.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.order.infrastructure;
+
+import kr.hhplus.be.server.order.domain.model.OrderItemJPA;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataOrderItemRepository extends JpaRepository<OrderItemJPA, Long> {
+}

--- a/src/main/java/kr/hhplus/be/server/order/infrastructure/SpringDataOrderRepository.java
+++ b/src/main/java/kr/hhplus/be/server/order/infrastructure/SpringDataOrderRepository.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.order.infrastructure;
+
+import kr.hhplus.be.server.order.domain.model.OrderJPA;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataOrderRepository extends JpaRepository<OrderJPA,Long> {
+}

--- a/src/main/java/kr/hhplus/be/server/order/usecase/OrderUseCaseImpl.java
+++ b/src/main/java/kr/hhplus/be/server/order/usecase/OrderUseCaseImpl.java
@@ -47,15 +47,11 @@ public class OrderUseCaseImpl implements OrderUseCase {
         Long couponId = command.couponId();
         List<OrderItemCommand> items = command.items();
 
-        // 1. 재고 확인
-        for (OrderItemCommand item : items) {
-            productCheckService.stockCheck(item.productId(), item.quantity());
-        }
+        //1. 재고 확인
+        productCheckService.validateAllStock(items);
 
-        // 2. 쿠폰 유효성 검사 (nullable)
-        if (couponId != null) {
-            couponCheckService.checkCoupon(userId, couponId);
-        }
+        //2. 쿠폰 유효성 검사 (nullable)
+        couponCheckService.checkIfValidCouponNullable(userId, couponId);
 
         // 3. 총 금액 계산 + 쿠폰 할인 적용 + 쿠폰사용 시 used로 변경
         long totalPrice = OrderPriceCalculator.calculateTotalPrice(items);
@@ -92,7 +88,7 @@ public class OrderUseCaseImpl implements OrderUseCase {
         // 7. 주문 이력 저장
         orderHistoryService.orderInsert(savedOrder, "결제완료");
 
-        // 8. 재고차감 -> 일부러 나중에 함 결제 완료 후
+        // 8. 재고차감 -> 일부러 나중에 함 결제 완료 후 -> 충돌 빈도가 높음
         orderItems.forEach(item ->
                 productDecreaseService.decreaseStock(
                         item.getProductId(),

--- a/src/main/java/kr/hhplus/be/server/point/domain/repository/UserPointHistoryRepository.java
+++ b/src/main/java/kr/hhplus/be/server/point/domain/repository/UserPointHistoryRepository.java
@@ -1,8 +1,12 @@
 package kr.hhplus.be.server.point.domain.repository;
 
 import kr.hhplus.be.server.point.domain.model.UserPointHistoryJPA;
-import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 
-public interface UserPointHistoryRepository extends JpaRepository<UserPointHistoryJPA, Long> {
+public interface UserPointHistoryRepository {
+
+    UserPointHistoryJPA save(UserPointHistoryJPA userPointHistoryJPA);
+     List<UserPointHistoryJPA> findAll();
 }

--- a/src/main/java/kr/hhplus/be/server/point/domain/repository/UserPointRepository.java
+++ b/src/main/java/kr/hhplus/be/server/point/domain/repository/UserPointRepository.java
@@ -1,7 +1,10 @@
 package kr.hhplus.be.server.point.domain.repository;
 
 import kr.hhplus.be.server.point.domain.model.UserPointJPA;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserPointRepository extends JpaRepository<UserPointJPA, Long> {
+public interface UserPointRepository {
+
+    UserPointJPA findById(Long id);
+    UserPointJPA save(UserPointJPA userPointJPA);
+    void deleteAll();  // 테스트용
 }

--- a/src/main/java/kr/hhplus/be/server/point/domain/service/PointChargeService.java
+++ b/src/main/java/kr/hhplus/be/server/point/domain/service/PointChargeService.java
@@ -27,8 +27,8 @@ public class PointChargeService {
         **계정이 없으면 새로운 계정을 만들고, 0포인트 반환함
         **포인트 충전
         */
-        UserPointJPA current = userPointRepo.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        UserPointJPA current = userPointRepo.findById(userId);
+
         current.charge(point);
 
         // 포인트 업데이트

--- a/src/main/java/kr/hhplus/be/server/point/domain/service/PointQueryService.java
+++ b/src/main/java/kr/hhplus/be/server/point/domain/service/PointQueryService.java
@@ -16,8 +16,7 @@ public class PointQueryService {
 
     public UserPointJPA GetPoint(long userId){
 
-        return userPointRepo.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User point not found for userId: " + userId));
+        return userPointRepo.findById(userId);
 
     }
 }

--- a/src/main/java/kr/hhplus/be/server/point/domain/service/PointUseService.java
+++ b/src/main/java/kr/hhplus/be/server/point/domain/service/PointUseService.java
@@ -6,7 +6,8 @@ import kr.hhplus.be.server.point.domain.model.UserPointJPA;
 import kr.hhplus.be.server.point.domain.repository.UserPointHistoryRepository;
 import kr.hhplus.be.server.point.domain.repository.UserPointRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 public class PointUseService {
@@ -28,8 +29,7 @@ public class PointUseService {
          **포인트 사용
          */
 
-        UserPointJPA current = userPointRepo.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        UserPointJPA current = userPointRepo.findById(userId);
         current.use(point);
 
         // 포인트 업데이트

--- a/src/main/java/kr/hhplus/be/server/point/infrastructure/SpringDataUserPointHistoryRepository.java
+++ b/src/main/java/kr/hhplus/be/server/point/infrastructure/SpringDataUserPointHistoryRepository.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.point.infrastructure;
+
+import kr.hhplus.be.server.point.domain.model.UserPointHistoryJPA;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataUserPointHistoryRepository extends JpaRepository<UserPointHistoryJPA, Long> {
+}

--- a/src/main/java/kr/hhplus/be/server/point/infrastructure/SpringDataUserPointRepository.java
+++ b/src/main/java/kr/hhplus/be/server/point/infrastructure/SpringDataUserPointRepository.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.point.infrastructure;
+
+import kr.hhplus.be.server.point.domain.model.UserPointJPA;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataUserPointRepository extends JpaRepository<UserPointJPA, Long> {
+}

--- a/src/main/java/kr/hhplus/be/server/point/infrastructure/UserPointHistoryRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/point/infrastructure/UserPointHistoryRepositoryImpl.java
@@ -1,0 +1,28 @@
+package kr.hhplus.be.server.point.infrastructure;
+
+import kr.hhplus.be.server.point.domain.model.UserPointHistoryJPA;
+
+import kr.hhplus.be.server.point.domain.repository.UserPointHistoryRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class UserPointHistoryRepositoryImpl implements UserPointHistoryRepository {
+
+    private final SpringDataUserPointHistoryRepository jpaRepository;
+
+    public UserPointHistoryRepositoryImpl(SpringDataUserPointHistoryRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public UserPointHistoryJPA save(UserPointHistoryJPA userPointHistoryJPA) {
+        return jpaRepository.save(userPointHistoryJPA);
+    }
+
+    @Override
+    public List<UserPointHistoryJPA> findAll() {
+        return jpaRepository.findAll();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/point/infrastructure/UserPointRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/point/infrastructure/UserPointRepositoryImpl.java
@@ -1,0 +1,35 @@
+package kr.hhplus.be.server.point.infrastructure;
+
+import kr.hhplus.be.server.point.domain.model.UserPointJPA;
+import kr.hhplus.be.server.point.domain.repository.UserPointRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class UserPointRepositoryImpl implements UserPointRepository {
+
+    private final SpringDataUserPointRepository jpaRepository;
+
+    public UserPointRepositoryImpl(SpringDataUserPointRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+
+    @Override
+    public UserPointJPA findById(Long id) {
+        return (jpaRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다.: " + id)));
+
+    }
+
+    @Override
+    public UserPointJPA save(UserPointJPA userPointJPA) {
+        return jpaRepository.save(userPointJPA);
+    }
+
+    @Override
+    public void deleteAll() {
+        jpaRepository.deleteAll();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/product/domain/repository/ProductHistoryRepository.java
+++ b/src/main/java/kr/hhplus/be/server/product/domain/repository/ProductHistoryRepository.java
@@ -1,10 +1,13 @@
 package kr.hhplus.be.server.product.domain.repository;
 
+
 import kr.hhplus.be.server.product.domain.model.ProductHistoryJPA;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface ProductHistoryRepository extends JpaRepository<ProductHistoryJPA, Long> {
+public interface ProductHistoryRepository{
+
+    ProductHistoryJPA save(ProductHistoryJPA productHistory);
+    List<ProductHistoryJPA> findAll();
 
 }

--- a/src/main/java/kr/hhplus/be/server/product/domain/repository/ProductRepository.java
+++ b/src/main/java/kr/hhplus/be/server/product/domain/repository/ProductRepository.java
@@ -1,11 +1,16 @@
 package kr.hhplus.be.server.product.domain.repository;
 
+
 import kr.hhplus.be.server.product.domain.model.ProductJPA;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface ProductRepository extends JpaRepository<ProductJPA, Long> {
+public interface ProductRepository {
+
+    Optional<ProductJPA> findById(long id);
+    ProductJPA save(ProductJPA product);
+    List<ProductJPA> findAll();
+
 
 }

--- a/src/main/java/kr/hhplus/be/server/product/domain/service/ProductCheckService.java
+++ b/src/main/java/kr/hhplus/be/server/product/domain/service/ProductCheckService.java
@@ -2,11 +2,13 @@ package kr.hhplus.be.server.product.domain.service;
 
 
 
+import kr.hhplus.be.server.order.usecase.dto.OrderItemCommand;
 import kr.hhplus.be.server.product.domain.model.ProductJPA;
 import kr.hhplus.be.server.product.domain.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,13 +17,18 @@ public class ProductCheckService {
 
     private final ProductRepository productRepository;
 
-    @Transactional(readOnly = true)
     public void stockCheck(Long productId, int requestQuantity) {
         ProductJPA product = productRepository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
 
         if (!product.stockCheck(requestQuantity)) {
             throw new IllegalStateException("재고 부족");
+        }
+    }
+
+    public void validateAllStock(List<OrderItemCommand> items) {
+        for (OrderItemCommand item : items) {
+            stockCheck(item.productId(), item.quantity());
         }
     }
 }

--- a/src/main/java/kr/hhplus/be/server/product/infrastructure/ProductHistoryRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/product/infrastructure/ProductHistoryRepositoryImpl.java
@@ -1,0 +1,28 @@
+package kr.hhplus.be.server.product.infrastructure;
+
+import kr.hhplus.be.server.product.domain.model.ProductHistoryJPA;
+import kr.hhplus.be.server.product.domain.repository.ProductHistoryRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@Repository
+public class ProductHistoryRepositoryImpl implements ProductHistoryRepository {
+
+    private final SpringDataProductHistoryRepository jpaRepository;
+
+    public ProductHistoryRepositoryImpl(SpringDataProductHistoryRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public ProductHistoryJPA save(ProductHistoryJPA productHistory) {
+        return jpaRepository.save(productHistory);
+    }
+
+    @Override
+    public List<ProductHistoryJPA> findAll() {
+        return jpaRepository.findAll();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/product/infrastructure/ProductRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/product/infrastructure/ProductRepositoryImpl.java
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.product.infrastructure;
+
+import kr.hhplus.be.server.product.domain.model.ProductJPA;
+import kr.hhplus.be.server.product.domain.repository.ProductRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class ProductRepositoryImpl implements ProductRepository {
+
+    private final SpringDataProductRepository jpaRepository;
+
+    public ProductRepositoryImpl(SpringDataProductRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<ProductJPA> findById(long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public ProductJPA save(ProductJPA product) {
+        return jpaRepository.save(product);
+    }
+
+    @Override
+    public List<ProductJPA> findAll() {
+        return jpaRepository.findAll();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/product/infrastructure/SpringDataProductHistoryRepository.java
+++ b/src/main/java/kr/hhplus/be/server/product/infrastructure/SpringDataProductHistoryRepository.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.product.infrastructure;
+
+import kr.hhplus.be.server.product.domain.model.ProductHistoryJPA;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataProductHistoryRepository extends JpaRepository<ProductHistoryJPA, Long> {
+}

--- a/src/main/java/kr/hhplus/be/server/product/infrastructure/SpringDataProductRepository.java
+++ b/src/main/java/kr/hhplus/be/server/product/infrastructure/SpringDataProductRepository.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.product.infrastructure;
+
+import kr.hhplus.be.server.product.domain.model.ProductJPA;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataProductRepository extends JpaRepository<ProductJPA, Long> {
+}

--- a/src/test/java/kr/hhplus/be/server/integrationTest/couponTest/CouponCheckServiceTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/couponTest/CouponCheckServiceTestIntegration.java
@@ -1,6 +1,5 @@
 package kr.hhplus.be.server.integrationTest.couponTest;
 
-import jakarta.transaction.Transactional;
 import kr.hhplus.be.server.TestcontainersConfiguration;
 import kr.hhplus.be.server.coupon.domain.model.CouponJPA;
 import kr.hhplus.be.server.coupon.domain.model.CouponUserJPA;
@@ -20,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
-public class CouponCheckServiceTestInte {
+public class CouponCheckServiceTestIntegration {
 
 
     @Autowired

--- a/src/test/java/kr/hhplus/be/server/integrationTest/couponTest/CouponControllerTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/couponTest/CouponControllerTestIntegration.java
@@ -14,7 +14,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -23,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class CouponControllerTestInte {
+public class CouponControllerTestIntegration {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/kr/hhplus/be/server/integrationTest/couponTest/CouponDiscountServiceTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/couponTest/CouponDiscountServiceTestIntegration.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -19,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
-public class CouponDiscountServiceTestInte {
+public class CouponDiscountServiceTestIntegration {
 
     @Autowired
     private CouponRepository couponRepository;

--- a/src/test/java/kr/hhplus/be/server/integrationTest/couponTest/CouponIssuedServiceTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/couponTest/CouponIssuedServiceTestIntegration.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -22,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
-public class CouponIssuedServiceTestInte {
+public class CouponIssuedServiceTestIntegration {
 
     @Autowired
     private CouponIssuedService couponIssuedService;

--- a/src/test/java/kr/hhplus/be/server/integrationTest/orderTest/OrderControllerTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/orderTest/OrderControllerTestIntegration.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-public class OrderControllerTestInte {
+public class OrderControllerTestIntegration {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/kr/hhplus/be/server/integrationTest/orderTest/OrderUseCaseTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/orderTest/OrderUseCaseTestIntegration.java
@@ -9,6 +9,7 @@ import kr.hhplus.be.server.coupon.domain.repository.CouponUserRepository;
 import kr.hhplus.be.server.order.domain.model.OrderJPA;
 import kr.hhplus.be.server.order.domain.repository.OrderRepository;
 import kr.hhplus.be.server.order.domain.service.dto.OrderStatus;
+import kr.hhplus.be.server.order.usecase.OrderUseCaseImpl;
 import kr.hhplus.be.server.order.usecase.dto.OrderCommand;
 import kr.hhplus.be.server.order.usecase.dto.OrderItemCommand;
 import kr.hhplus.be.server.order.usecase.dto.OrderResult;
@@ -23,8 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
-import org.testcontainers.junit.jupiter.Testcontainers;
+
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -32,13 +32,13 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 @SpringBootTest
-@Import(TestcontainersConfiguration.class)
-public class OrderUseCaseTestInte {
+@Import({TestcontainersConfiguration.class, OrderUseCaseImpl.class})
+public class OrderUseCaseTestIntegration {
 
     @Autowired
     OrderUseCase orderUseCase;
+
 
     @Autowired
     ProductRepository productRepository;

--- a/src/test/java/kr/hhplus/be/server/integrationTest/pointTest/PointChargeControllerTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/pointTest/PointChargeControllerTestIntegration.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class PointChargeControllerTestInte {
+public class PointChargeControllerTestIntegration {
 
     @Autowired
     private MockMvc mockMvc;
@@ -54,7 +54,7 @@ public class PointChargeControllerTestInte {
                 .andExpect(status().isOk());
 
         // DB에서 결과 확인
-        UserPointJPA updatedUserPoint = userPointRepository.findById(userId).orElseThrow();
+        UserPointJPA updatedUserPoint = userPointRepository.findById(userId);
         assertThat(updatedUserPoint.getPoint()).isEqualTo(15000L);
     }
 }

--- a/src/test/java/kr/hhplus/be/server/integrationTest/pointTest/PointChargeUseCaseTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/pointTest/PointChargeUseCaseTestIntegration.java
@@ -10,14 +10,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
-public class PointChargeUseCaseTestInte {
+public class PointChargeUseCaseTestIntegration {
 
     @Autowired
     private PointChargeUseCase pointChargeUseCase;
@@ -40,7 +39,7 @@ public class PointChargeUseCaseTestInte {
         // then: DB에 반영된 결과 확인
         assertThat(response.point()).isEqualTo(initialPoint + chargeAmount);
 
-        UserPointJPA updatedUserPoint = userPointRepository.findById(userId).orElseThrow();
+        UserPointJPA updatedUserPoint = userPointRepository.findById(userId);
         assertThat(updatedUserPoint.getPoint()).isEqualTo(initialPoint + chargeAmount);
     }
 

--- a/src/test/java/kr/hhplus/be/server/integrationTest/pointTest/PointQueryControllerTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/pointTest/PointQueryControllerTestIntegration.java
@@ -18,7 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class PointQueryControllerTestInte {
+public class PointQueryControllerTestIntegration {
 
     @Autowired
     private MockMvc mockMvc;
@@ -46,7 +46,7 @@ public class PointQueryControllerTestInte {
                 .andExpect(jsonPath("$.point").value(10000L));
 
         // DB 직접 조회로 값 검증
-        UserPointJPA userPoint = userPointRepository.findById(userId).orElseThrow();
+        UserPointJPA userPoint = userPointRepository.findById(userId);
         assertThat(userPoint.getPoint()).isEqualTo(10000L);
     }
 }

--- a/src/test/java/kr/hhplus/be/server/integrationTest/pointTest/PointQueryServiceTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/pointTest/PointQueryServiceTestIntegration.java
@@ -10,13 +10,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
-public class PointQueryServiceTestInte {
+public class PointQueryServiceTestIntegration {
 
     @Autowired
     private UserPointRepository userPointRepository;

--- a/src/test/java/kr/hhplus/be/server/integrationTest/pointTest/PointUseServiceTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/pointTest/PointUseServiceTestIntegration.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -20,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
-public class PointUseServiceTestInte {
+public class PointUseServiceTestIntegration {
 
     @Autowired
     private PointUseService pointUseService;

--- a/src/test/java/kr/hhplus/be/server/integrationTest/productTest/ProductDecreaseServiceTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/productTest/ProductDecreaseServiceTestIntegration.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -17,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
-public class ProductDecreaseServiceTestInte {
+public class ProductDecreaseServiceTestIntegration {
 
     @Autowired
     private ProductRepository productRepository;

--- a/src/test/java/kr/hhplus/be/server/integrationTest/productTest/ProductFindServiceTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/productTest/ProductFindServiceTestIntegration.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -20,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
-public class ProductFindServiceTestInte {
+public class ProductFindServiceTestIntegration {
 
 
     @Autowired

--- a/src/test/java/kr/hhplus/be/server/integrationTest/productTest/ProductHistoryServiceTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/productTest/ProductHistoryServiceTestIntegration.java
@@ -10,13 +10,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
-public class ProductHistoryServiceTestInte {
+public class ProductHistoryServiceTestIntegration {
 
     @Autowired
     private ProductHistoryRepository productHistoryRepository;

--- a/src/test/java/kr/hhplus/be/server/integrationTest/productTest/ProductStockCheckTestIntegration.java
+++ b/src/test/java/kr/hhplus/be/server/integrationTest/productTest/ProductStockCheckTestIntegration.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -20,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
-public class ProductStockCheckTestInte {
+public class ProductStockCheckTestIntegration {
 
     @Autowired
     ProductRepository productRepository;

--- a/src/test/java/kr/hhplus/be/server/unittest/couponTest/CouponCheckServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/unittest/couponTest/CouponCheckServiceTest.java
@@ -59,7 +59,7 @@ public class CouponCheckServiceTest {
                  userId, couponId, false, null, LocalDateTime.now()
         );
 
-        given(couponRepository.findByCouponId(couponId)).willReturn(Optional.of(coupon.toEntity()));
+        given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon.toEntity()));
         given(couponUserRepository.findByUserIdAndCouponId(userId, couponId)).willReturn(Optional.of(couponUser.toEntity()));
 
 
@@ -72,7 +72,7 @@ public class CouponCheckServiceTest {
     void checkCoupon_notFound() {
 
         // given
-        given(couponRepository.findByCouponId(couponId)).willReturn(Optional.empty());
+        given(couponRepository.findById(couponId)).willReturn(Optional.empty());
 
         // expect
         assertThatThrownBy(() -> service.checkCoupon(userId, couponId))
@@ -90,7 +90,7 @@ public class CouponCheckServiceTest {
                 LocalDateTime.now().minusDays(1),
                 LocalDateTime.now(), LocalDateTime.now()
         );
-        given(couponRepository.findByCouponId(couponId)).willReturn(Optional.of(expiredCoupon.toEntity()));
+        given(couponRepository.findById(couponId)).willReturn(Optional.of(expiredCoupon.toEntity()));
 
         // expect
         assertThatThrownBy(() -> service.checkCoupon(userId, couponId))
@@ -108,7 +108,7 @@ public class CouponCheckServiceTest {
                 LocalDateTime.now().plusDays(1),
                 LocalDateTime.now(), LocalDateTime.now()
         );
-        given(couponRepository.findByCouponId(couponId)).willReturn(Optional.of(validCoupon.toEntity()));
+        given(couponRepository.findById(couponId)).willReturn(Optional.of(validCoupon.toEntity()));
         given(couponUserRepository.findByUserIdAndCouponId(userId, couponId)).willReturn(Optional.empty());
 
         // expect
@@ -132,7 +132,7 @@ public class CouponCheckServiceTest {
                 LocalDateTime.now().minusDays(1),
                 LocalDateTime.now().minusDays(2)
         );
-        given(couponRepository.findByCouponId(couponId)).willReturn(Optional.of(validCoupon.toEntity()));
+        given(couponRepository.findById(couponId)).willReturn(Optional.of(validCoupon.toEntity()));
         given(couponUserRepository.findByUserIdAndCouponId(userId, couponId)).willReturn(Optional.of(usedCoupon.toEntity()));
 
         // expect

--- a/src/test/java/kr/hhplus/be/server/unittest/couponTest/CouponDiscountServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/unittest/couponTest/CouponDiscountServiceTest.java
@@ -52,7 +52,7 @@ public class CouponDiscountServiceTest {
                 LocalDateTime.now()
         );
 
-        given(couponRepository.findByCouponId(couponId))
+        given(couponRepository.findById(couponId))
                 .willReturn(Optional.of(coupon.toEntity()));
 
         // when

--- a/src/test/java/kr/hhplus/be/server/unittest/couponTest/CouponIssuedServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/unittest/couponTest/CouponIssuedServiceTest.java
@@ -59,7 +59,7 @@ public class CouponIssuedServiceTest {
                 LocalDateTime.now(),
                 LocalDateTime.now()
         );
-        given(couponRepository.findByCouponId(couponId)).willReturn(Optional.of(coupon.toEntity()));
+        given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon.toEntity()));
         given(couponUserRepository.findByUserIdAndCouponId(userId, couponId)).willReturn(Optional.empty());
         given(couponUserRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
 

--- a/src/test/java/kr/hhplus/be/server/unittest/pointTest/PointChargeServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/unittest/pointTest/PointChargeServiceTest.java
@@ -41,7 +41,7 @@ public class PointChargeServiceTest {
         long existingPoint = 10000L;
         UserPointJPA existing = new UserPointJPA(userId, existingPoint,System.currentTimeMillis());
         // 고정된 ID 1L에 대해 항상 이 UserPoint를 줘야 할 때
-        Mockito.when(userPointRepository.findById(userId)).thenReturn(Optional.of(existing));
+        Mockito.when(userPointRepository.findById(userId)).thenReturn(existing);
 
         // 저장할 때마다 들어오는 객체가 다를 수 있음 → 그대로 리턴
         Mockito.when(userPointRepository.save(Mockito.any(UserPointJPA.class)))

--- a/src/test/java/kr/hhplus/be/server/unittest/pointTest/PointQueryServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/unittest/pointTest/PointQueryServiceTest.java
@@ -34,7 +34,7 @@ public class PointQueryServiceTest {
         long userId = 1L;
         long existingPoint = 10000L;
         UserPointJPA existing = new UserPointJPA (userId, existingPoint,System.currentTimeMillis());
-        Mockito.when(userPointRepository.findById(userId)).thenReturn(Optional.of(existing));
+        Mockito.when(userPointRepository.findById(userId)).thenReturn(existing);
         /*when*/
         UserPointJPA  result = PointQueryService.GetPoint(userId);
 

--- a/src/test/java/kr/hhplus/be/server/unittest/pointTest/PointUseServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/unittest/pointTest/PointUseServiceTest.java
@@ -40,7 +40,7 @@ public class PointUseServiceTest {
         long existingPoint = 10000L;
         UserPointJPA existing = new UserPointJPA(userId, existingPoint,System.currentTimeMillis());
         // 고정된 ID 1L에 대해 항상 이 UserPoint를 줘야 할 때
-        Mockito.when(userPointRepository.findById(userId)).thenReturn(Optional.of(existing));
+        Mockito.when(userPointRepository.findById(userId)).thenReturn(existing);
 
         // 저장할 때마다 들어오는 객체가 다를 수 있음 → 그대로 리턴
         Mockito.when(userPointRepository.save(Mockito.any(UserPointJPA.class)))


### PR DESCRIPTION
PR 템플릿
## :pushpin: [STEP09][STEP10] 이재호 - e-commerce


---

## :clipboard: 핵심 체크리스트 :white_check_mark:

### STEP09 - Concurrency (2개)
- [X] 애플리케이션 내에서 발생 가능한 **동시성 문제를 식별**했는가?
- [X] 보고서에 DB를 활용한 **동시성 문제 해결 방안**이 포함되어 있는가?

---

## 1. 문제 식별: e-commerce 서비스의 동시성 이슈

e-commerce 시스템에서는 다수의 사용자가 동시에 아래와 같은 작업을 수행할 수 있으며, 적절한 동시성 제어가 없을 경우 심각한 
데이터 정합성 문제가 발생할 수 있습니다.

### 주요 동시성 발생 지점

1. **같은 쿠폰의 중복 사용**
   - 사용자 A와 B가 동시에 동일한 쿠폰을 사용하면, 쿠폰이 중복 적용되어 할인 금액이 잘못 반영됨
2. **같은 상품의 초과 주문**
   - 상품 재고가 5개일 때, A와 B가 동시에 각각 3개씩 주문할 경우 총 6개가 주문되어 재고가 음수로 내려감
3. **포인트의 동시 차감**
   - 사용자의 보유 포인트가 10,000일 때, A와 B가 동시에 7,000 포인트를 사용하면 총 14,000 포인트가 차감됨
4. **선착순 쿠폰의 초과 발급**
   - 쿠폰의 발급 한도가 100개인데, 동시에 수백 명이 요청을 보내는 경우, 120명 이상에게 쿠폰이 발급될 수 있음

### 결과적으로 발생 가능한 문제

| 문제 사례              | 설명                                                                 |
|-----------------------|----------------------------------------------------------------------|
| 쿠폰 중복 사용         | 제한된 쿠폰이 다수 사용자에게 중복 적용됨                             |
| 재고 초과 주문         | 상품의 실제 재고보다 많은 수량이 판매되어 물류/환불 이슈 발생          |
| 포인트 초과 차감       | 사용자가 실제 보유한 포인트 이상을 동시에 사용하게 되어 정산 오류 발생         |
| **선착순 쿠폰 초과 발급** | "100명 한정" 쿠폰이 동시 요청 처리 중 120명에게 발급되어 마케팅 신뢰도 하락 |

이러한 문제는 대부분 트랜잭션 경계 설정 미흡, DB 레벨 Lock 부족, 혹은 계산과 저장의 시간 차로 인한 **Race Condition**에 의해
발생합니다.

Race Condition이란?!
여러 개의 스레드나 트랜잭션이 동시에 같은 데이터에 접근하고, 그 결과가 실행 순서(타이밍)에 따라 달라지는 상황을 말한다.





##2. 원인 분석: 왜 동시성 문제가 발생했는가?

전자상거래 서비스에서 발생하는 여러 동시성 문제는 대부분 `Race Condition` 때문에 생깁니다.

---

### 1. **쿠폰 중복 사용**

- 쿠폰을 한 계정에서 1개만 쓸 수 있어야 하는데, 동시에 한 계정으로 같은 쿠폰을 쓰면?
- **사용 여부를 먼저 확인하고, 나중에 저장**하기 때문에 중간에 다른 사용자가 끼어들 수 있음.
- 그래서 둘 다 "사용 안 했네?" 하고 통과한 다음 둘 다 사용하게 됨.

---

### 2. **상품 재고 초과 주문**

- 예: 재고가 5개인데, 두 명이 동시에 3개씩 주문
- 둘 다 `재고 5`를 읽고, 각각 `-3` 해서 저장 → 최종 재고는 -1
- 원인은 "재고를 읽고, 차감하고, 저장하는 과정이 나눠져 있기 때문

---

### 3. **포인트 동시 차감**

- A사용자가 We과 모바일에서 동시에 포인트를 쓰면?
- 서로 같은 시점에 보유 포인트를 읽고 계산 → 동시에 저장 → 결국 실제보다 더 많이 차감
- 포인트는 곧 돈이므로 고객에게 가장 큰 이슈가 발생함

---

### 4. **선착순 쿠폰 초과 발급**

- 100개만 나눠줘야 하는 쿠폰을 동시에 수백 명이 요청하면?
- 여러 사용자가 "발급 수량 아직 100개 안 넘었네?" 하고 동시에 통과 → 결국 150명에게 발급됨
- 원인은 `issued_quantity` 증가하는 작업이 서로 겹쳐서 덮어써졌기 때문

---

###  공통적인 원인 정리

| 상황              | 문제가 생기는 이유                           |
|-------------------|-----------------------------------------------|
| 쿠폰 사용          | "사용 안 했는지" 확인 → 그 사이 1계정으로 동시에 2개 사용 |
| 재고 차감          | 재고 수를 먼저 읽고 → 나중에 저장해서 충돌 발생     |
| 포인트 차감        | 포인트 잔액 확인 → 다른 매개체로(Web/Mobile)동시에 사용하면 값이 꼬임       |
| 쿠폰 발급          | 발급 수량을 먼저 체크하고 → 동시에 증가시킴         |

---

### 한 줄 요약

> **읽고 → 계산하고 → 저장하는 과정이 나눠져 있으면, 그 사이 다른 사람이 작업을 끼워 넣을 수 있어서 문제가 생깁니다.**

---

이런 문제를 해결하려면 데이터베이스나 애플리케이션에서 **"순차적으로 처리"하거나 "먼저 잠그고(Lock) 작업"하는 방법**이 필요.





## 3. 해결 방법: DB 락 관점에서의 동시성 제어 전략

**DB 수준의 락(Pessimistic / Optimistic Lock)을 기반으로 한 해결 전략**을 아래와 같이 정리합니다.

---

### 1. 쿠폰 중복 사용(비관적락)

- **문제 요약**: 하나의 쿠폰이 동시에 여러 요청에서 사용되어 중복 할인 발생

- **해결 전략**
  - 쿠폰 사용 상태를 확인하고 수정하는 부분에 **비관적 락(Pessimistic Lock)** 적용
    ```java
    @Lock(LockModeType.PESSIMISTIC_WRITE)
    @Query("SELECT c FROM CouponUser c WHERE c.userId = :userId AND c.couponId = :couponId")
    CouponUser findByUserIdAndCouponIdWithLock(...)
    ```

- **선택 이유**
  - 쿠폰은 한 번만 쓸 수 있는 자원이므로, 중복 사용은 절대 발생하면 안 됨
  - 락을 걸고 작업하는 것이 가장 확실한 방식

---

### 2. 상품 재고 초과 주문(낙관적락)

- **문제 요약**: 재고보다 많은 수량이 동시에 주문되어 재고가 음수로 내려감

- **해결 전략**
  - 상품 테이블에 **낙관적 락(Optimistic Lock)** 적용
    - `@Version` 필드로 버전 관리
    - 주문 요청 시 재고 조회 → 차감 → 저장
    - 저장 시 버전 충돌이 발생하면 예외 발생 → 재시도

    ```java
    @Version
    private Long version;
    ```

- **선택 이유**
  - 주문량이 많고 성능이 중요함 → 락 대기보다 **낙관적 락**이 더 효율적
  - 충돌 발생 시만 처리하면 되므로 확장성 좋음

---

### 3. 포인트 동시 차감(비관적락)

- **문제 요약**: 동시에 포인트를 차감하면 보유 포인트보다 많은 금액이 빠질 수 있음

- **해결 전략**
  - 포인트 테이블에 **비관적 락(Pessimistic Lock)** 적용
    ```java
    @Lock(LockModeType.PESSIMISTIC_WRITE)
    @Query("SELECT p FROM UserPoint p WHERE p.userId = :userId")
    UserPoint findByUserIdWithLock(...)
    ```

- **선택 이유**
  - 포인트는 돈과 동일한 자산 → 실수나 충돌이 절대 발생하면 안 됨
  - 정확성과 정합성이 매우 중요하기 때문에 락을 걸고 처리하는 방식이 적절

---

### 4. 선착순 쿠폰 초과 발급(비관적락)

- **문제 요약**: 한정 수량 쿠폰을 동시에 많은 사용자가 요청해 초과 발급되는 현상

- **해결 전략**
  - 쿠폰 테이블에 **비관적 락(Pessimistic Lock)** 적용
    - 쿠폰 행 조회 시 락을 걸고 `issued_quantity` 증가
    - 발급 수량 조건 검증 후 처리

    ```java
    @Lock(LockModeType.PESSIMISTIC_WRITE)
    @Query("SELECT c FROM Coupon c WHERE c.id = :couponId")
    Coupon findByIdWithLock(...)
    ```

- **선택 이유**
  - 선착순은 수량 기준으로 발급을 제한해야 하므로, 정확한 순서 보장이 중요
  - 동시에 많은 요청이 들어와도 한 명씩 처리되도록 락을 걸어야 안전함





### STEP10 - Finalize (1개)
- [X] **동시성 문제를 드러낼 수 있는 통합 테스트**를 작성했는가?

---

## ✍️ 간단 회고 (3줄 이내)
- **잘한 점**: 동시성 문제가 발생 할 수 있는 부분에 대해서 문제 식별을 잘 했고 해당 시나리오에 대해서 테스트 통합 테스트 코드를 잘 구현함
- **어려웠던 점**: 트랜잭션의 위치와 어떨때 트랜잭션이 무시되는지 어려웠습니다. -> 아직도 이해가 잘 안됩니다. 프록시 객체로 수정을 하긴 했습니다.
     (AOP(Aspect-Oriented Programming) 기반으로 작동하는데 같은 클래스 내부에서 메서드를 호출하면, 트랜잭션 적용이 안 됨)
- **다음 시도**: 롤백에 로직에대해서 더 공부하고, 이제 락에대해서 자유롭게 쓰고싶습니다.(특히 트랜잭션) 